### PR TITLE
Adding leave accrual table (no policy changes)

### DIFF
--- a/handbook/handbook.md
+++ b/handbook/handbook.md
@@ -219,9 +219,19 @@ Employees must inform your supervisor in writing as far in advance as is reasona
 
 To schedule time off, permission must be granted by your supervisor no less than 5 business days in advance, the dates your travel must be put onto your work calendar and the team should be notified. 
 
+Employees accrue hours of paid leave for every year they work:
+
+| After  | Hours accrued |
+| ------------- | ------------- |
+| Start day  | 96  |
+| +1 year  | 104  |
+| +2 years    | 112  |
+| +3 years    | 120  |
+
+Employees may hold a maximum of 240 hours of accrued leave.
+
 [Use Gusto to request and track time off](https://app.gusto.com/free-law-project/employee/time_off).
 
-There is a maximum of 240 hours of paid time off.
 
 ### Sick Days
 Please notify the team if you are sick and need to take the day off. All employees accrue one hour of sick time per 30 hours of employment with a cap of 80 hours of sick time available.

--- a/handbook/handbook.md
+++ b/handbook/handbook.md
@@ -215,9 +215,9 @@ We expect everyone to be able to get their work done in a timely fashion, and to
 We encourage employees to **use** their vacation time.
 
 #### Taking Leave
-Employees must inform your supervisor in writing as far in advance as is reasonable for staff and project planning purposes. All extended periods of leave must be discussed with the Executive Director.
+You must inform your supervisor in writing as far in advance as is reasonable for staff and project planning purposes. Your supervisor must grant permission no less than 5 business days in advance. All extended periods of leave must be discussed with the Executive Director.
 
-To schedule time off, permission must be granted by your supervisor no less than 5 business days in advance, the dates your travel must be put onto your work calendar and the team should be notified. 
+Please add the dates your travel to your work calendar and notify the team when you take leave. 
 
 Employees accrue hours of paid leave for every year they work:
 

--- a/handbook/handbook.md
+++ b/handbook/handbook.md
@@ -2,6 +2,7 @@
 
 ## Version history
 
+ - v1.4.4, 2024-03-03 - Add PTO accrual table
  - v1.4.3, 2024-02-26 - Add details to PTO policy
  - v1.4.2, 2023-06-18 - Add/clarify mileage reimbursement
  - v1.4.1, 2022-04-14 - Note max PTO time


### PR DESCRIPTION
Thought it might be helpful to add the leave accrual table (from Gusto) to the HR handbook. That might save @mlissner a few emails with future job candidates. 

In this PR, I:
* Add said accrual table
* Re-phrase the surrounding text to make the "sick leave" and "taking leave" sections consistent
* Add a new version number / comment

I don't think this change represents any changes to the policies themselves. 